### PR TITLE
Update to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,1 @@
-# Script's Chunk Loaders
-
-> Make minecarts act as chunk loaders using redstone.
-
-All information is [available on Modrinth](https://modrinth.com/mod/scripts-chunk-loaders).
-
-🙏 Currently the deployment setup for [all of my mods](https://modrinth.com/collection/7JZGuXDg)
-(not a lot right now) is quite odd. I can't release older versions easily and I
-have to bump the mod version to update the Minecraft version. If you have
-experience with Minecraft modding and a good idea of how to automate this in a
-better way, please feel free to [reach out](https://github.com/scriptcoded).
+# Fork from [scripts-chunk-loaders](https://github.com/scriptcoded/scripts-chunk-loaders)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Fork from [scripts-chunk-loaders](https://github.com/scriptcoded/scripts-chunk-loaders)
+
+Created a fork for the update to 1.21

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# Fork from [scripts-chunk-loaders](https://github.com/scriptcoded/scripts-chunk-loaders)
+# Script's Chunk Loaders
 
-Created a fork for the update to 1.21
+> Make minecarts act as chunk loaders using redstone.
+All information is [available on Modrinth](https://modrinth.com/mod/scripts-chunk-loaders).
+
+🙏 Currently the deployment setup for [all of my mods](https://modrinth.com/collection/7JZGuXDg)
+(not a lot right now) is quite odd. I can't release older versions easily and I
+have to bump the mod version to update the Minecraft version. If you have
+experience with Minecraft modding and a good idea of how to automate this in a
+better way, please feel free to [reach out](https://github.com/scriptcoded).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Script's Chunk Loaders
 
 > Make minecarts act as chunk loaders using redstone.
+> 
 All information is [available on Modrinth](https://modrinth.com/mod/scripts-chunk-loaders).
 
 🙏 Currently the deployment setup for [all of my mods](https://modrinth.com/collection/7JZGuXDg)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Script's Chunk Loaders
 
 > Make minecarts act as chunk loaders using redstone.
-> 
+
 All information is [available on Modrinth](https://modrinth.com/mod/scripts-chunk-loaders).
 
 🙏 Currently the deployment setup for [all of my mods](https://modrinth.com/collection/7JZGuXDg)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.5-SNAPSHOT'
+	id 'fabric-loom' version '1.6-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
-loader_version=0.15.7
+minecraft_version=1.21
+yarn_mappings=1.21+build.2
+loader_version=0.15.11
 
 # Mod Properties
 # x-release-please-start-version
@@ -16,4 +16,4 @@ maven_group=io.nihlen.scriptschunkloaders
 archives_base_name=scripts-chunk-loaders
 
 # Dependencies
-fabric_version=0.96.4+1.20.4
+fabric_version=0.100.1+1.21

--- a/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
@@ -125,15 +125,14 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Mine
 	}
 
 	@Override
-	public Entity teleportTo(TeleportTarget teleportTarget)
-	{
+	public Entity teleportTo(TeleportTarget teleportTarget) {
 		var wasChunkLoader = isChunkLoader;
-		if(wasChunkLoader)
+		if (wasChunkLoader)
 			this.scripts_chunk_loaders$stopChunkLoader();
 
 		var newEntity = super.teleportTo(teleportTarget);
 
-		if(wasChunkLoader && newEntity != null)
+		if (wasChunkLoader && newEntity != null)
 			((AbstractMinecartEntityMixin)newEntity).scripts_chunk_loaders$startChunkLoader();
 
 		return newEntity;

--- a/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
@@ -83,12 +83,17 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Mine
 	}
 
 	public void scripts_chunk_loaders$stopChunkLoader() {
+		scripts_chunk_loaders$stopChunkLoader(false);
+	}
+	public void scripts_chunk_loaders$stopChunkLoader(Boolean keepName) {
 		this.isChunkLoader = false;
 
 		ScriptsChunkLoadersMod.CHUNK_LOADER_MANAGER.removeChunkLoader(this);
 
-		this.setCustomName(null);
-		this.setCustomNameVisible(false);
+		if (!keepName) {
+			this.setCustomName(null);
+			this.setCustomNameVisible(false);
+		}
 	}
 
 	@Inject(method = "writeCustomDataToNbt", at = @At("RETURN"))
@@ -128,7 +133,7 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Mine
 	public Entity teleportTo(TeleportTarget teleportTarget) {
 		var wasChunkLoader = isChunkLoader;
 		if (wasChunkLoader)
-			this.scripts_chunk_loaders$stopChunkLoader();
+			this.scripts_chunk_loaders$stopChunkLoader(true);
 
 		var newEntity = super.teleportTo(teleportTarget);
 

--- a/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
@@ -1,6 +1,8 @@
 package io.nihlen.scriptschunkloaders.mixin;
 
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.vehicle.*;
+import net.minecraft.world.TeleportTarget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;

--- a/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartEntityMixin.java
@@ -62,7 +62,9 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Mine
 			var entity = (ChestMinecartEntity)(Object)this;
 			var firstSlot = entity.getInventory().get(0);
 
-			if (!firstSlot.isEmpty() && firstSlot.hasCustomName()) {
+			var hasCustomName = firstSlot.get(DataComponentTypes.CUSTOM_NAME) != null;
+			
+			if (!firstSlot.isEmpty() && hasCustomName) {
 				var name = firstSlot.getName().getString();
 				scripts_chunk_loaders$setChunkLoaderName(name);
 				return;
@@ -121,17 +123,16 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Mine
 	}
 
 	@Override
-	public Entity moveToWorld(ServerWorld destination) {
+	public Entity teleportTo(TeleportTarget teleportTarget)
+	{
 		var wasChunkLoader = isChunkLoader;
-		if (wasChunkLoader) {
+		if(wasChunkLoader)
 			this.scripts_chunk_loaders$stopChunkLoader();
-		}
 
-		var newEntity = super.moveToWorld(destination);
+		var newEntity = super.teleportTo(teleportTarget);
 
-		if (wasChunkLoader && newEntity != null) {
+		if(wasChunkLoader && newEntity != null)
 			((AbstractMinecartEntityMixin)newEntity).scripts_chunk_loaders$startChunkLoader();
-		}
 
 		return newEntity;
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
 		"scripts-chunk-loaders.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.15.7",
-		"minecraft": "1.20.4",
-		"java": ">=17",
+		"fabricloader": ">=0.15.11",
+		"minecraft": "1.21",
+		"java": ">=21",
 		"fabric-api": "*"
 	}
 }


### PR DESCRIPTION
Version changes
- Increased the Versions as described at the [fabric develop](https://fabricmc.net/develop/) website

Some changes to the `AbstractMinecartEntityMixin`
- The `hasCustomName` seems to be gone, so I manually check for a custom name
- The `moveToWorld` was replaced with `teleportTo`