### PR TITLE
Compatibility with 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = "mc${project.minecraft_version}-${project.mod_version}"
@@ -27,7 +27,6 @@ loom {
             sourceSet sourceSets.client
         }
     }
-
 }
 
 dependencies {
@@ -54,7 +53,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
+minecraft_version=1.21.1
+minecraft_version_range=>=1.21 <1.22
 yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 # Mod Properties
 # x-release-please-start-version
-mod_version=0.3.1
+mod_version=0.3.2
 # x-release-please-end
 maven_group=io.nihlen.scriptschunkloaders
 archives_base_name=scripts-chunk-loaders
 
 # Dependencies
-fabric_version=0.100.1+1.21
+fabric_version=0.102.0+1.21.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
-		"minecraft": "1.21",
+		"minecraft": ">=1.21",
 		"java": ">=21",
 		"fabric-api": "*"
 	}


### PR DESCRIPTION
Adds basic compatibility with 1.21.1. Missing (auto)generated changelog.
Can be found [here](https://github.com/lesCrayons/scripts-chunk-loaders/releases/tag/v0.3.2) in the meantime.