### PR TITLE
fix: reduce log spam

### DIFF
--- a/src/main/java/io/nihlen/scriptschunkloaders/ChunkLoaderManager.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/ChunkLoaderManager.java
@@ -32,7 +32,7 @@ public class ChunkLoaderManager {
     }
 
     private void handlePendingRegistrations () {
-        ScriptsChunkLoadersMod.LOGGER.info("Handling pending registrations");
+        ScriptsChunkLoadersMod.LOGGER.debug("Handling pending registrations");
         pendingRegistrations.forEach(this::registerChunkLoader);
         pendingRegistrations.clear();
     }
@@ -46,7 +46,7 @@ public class ChunkLoaderManager {
         var chunkPos = entity.chunkPosition();
 
         removeChunkLoader(entity);
-        ScriptsChunkLoadersMod.LOGGER.info("Adding {} to {}", entity, entity.level().dimension().identifier());
+        ScriptsChunkLoadersMod.LOGGER.debug("Adding {} to {}", entity, entity.level().dimension().identifier());
 
         var worldRegistryKey = entity.level().dimension();
         var worldChunks = forceLoadedChunks.computeIfAbsent(worldRegistryKey, s -> new HashMap<>());
@@ -55,13 +55,13 @@ public class ChunkLoaderManager {
     }
 
     public void removeChunkLoader(Entity entity) {
-        ScriptsChunkLoadersMod.LOGGER.info("Removing {} from {}", entity, entity.level().dimension().identifier());
+        ScriptsChunkLoadersMod.LOGGER.debug("Removing {} from {}", entity, entity.level().dimension().identifier());
         var uuid = entity.getUUID();
 
         var worldRegistryKey = entity.level().dimension();
         var worldChunks = forceLoadedChunks.get(worldRegistryKey);
 
-        ScriptsChunkLoadersMod.LOGGER.info("worldChunks {}", worldChunks);
+        ScriptsChunkLoadersMod.LOGGER.debug("worldChunks {}", worldChunks);
         if (worldChunks == null) return;
 
         var iterator = worldChunks.entrySet().iterator();

--- a/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartMixin.java
+++ b/src/main/java/io/nihlen/scriptschunkloaders/mixin/AbstractMinecartMixin.java
@@ -57,7 +57,7 @@ public abstract class AbstractMinecartMixin extends Entity implements MinecartEn
 
 		this.isChunkLoader = true;
 
-		ScriptsChunkLoadersMod.LOGGER.info("Starting chunk loader in {}", this.level().dimension().identifier());
+		ScriptsChunkLoadersMod.LOGGER.info("Starting chunk loader (ID: {}) at ({}, {}, {}) in {}", this.getId(), (int) this.getX(), (int) this.getY(), (int) this.getZ(), this.level().dimension().identifier());
 	}
 
 	public void scripts_chunk_loaders$setChunkLoaderNameFromInventory() {
@@ -92,6 +92,7 @@ public abstract class AbstractMinecartMixin extends Entity implements MinecartEn
 	}
 	@Unique
 	public void scripts_chunk_loaders$stopChunkLoader(Boolean keepName) {
+		ScriptsChunkLoadersMod.LOGGER.info("Stopping chunk loader '{}' (ID: {}) at ({}, {}, {}) in {}", this.getName().getString(), this.getId(), (int) this.getX(), (int) this.getY(), (int) this.getZ(), this.level().dimension().identifier());
 		this.isChunkLoader = false;
 
 		ScriptsChunkLoadersMod.CHUNK_LOADER_MANAGER.removeChunkLoader(this);
@@ -119,7 +120,7 @@ public abstract class AbstractMinecartMixin extends Entity implements MinecartEn
 		var chunkPos = this.chunkPosition();
 		if (lastChunkPos == null || lastChunkPos != chunkPos) {
 			lastChunkPos = chunkPos;
-			ScriptsChunkLoadersMod.LOGGER.info("Re-registering chunk loader");
+			ScriptsChunkLoadersMod.LOGGER.debug("Re-registering chunk loader");
 			ScriptsChunkLoadersMod.CHUNK_LOADER_MANAGER.registerChunkLoader(this);
 		}
 


### PR DESCRIPTION
Fix for #28 by adjusting Log level of re-registration messages to debug.

The only messages the user should see in their console now are when a new chunk loader get's added and when one is removed. I improved those messages with additional info.

In my opinion these two messages should remain info as they don't happen too frequently and should be helpful for when chunkloaders are being spammed on a server which would likely lead to a very high server load.